### PR TITLE
Also allow sharing by people higher in the role-hierarchy

### DIFF
--- a/force-app/main/default/classes/LightningSharing.cls
+++ b/force-app/main/default/classes/LightningSharing.cls
@@ -5,22 +5,12 @@ global with sharing class LightningSharing {
 	@AuraEnabled
 	global static boolean canIEditPerms(id recordId){
 		try {
-			//if you're the owner, you're cool
-			string query = 'select ownerId from ' + objectTypeFromId(recordId) + ' where id = \'' + String.escapeSingleQuotes(string.valueOf(recordId)) + '\'';
-			sobject o = database.query(query);
-			if (o.get('ownerId') == userInfo.getUserID()){
-				system.debug('edit allowed because owner');
-				return true;
-			}
-
-			//if you have modify allData, you're also cool
-			list<PermissionSetAssignment> modifiers = [SELECT AssigneeId FROM PermissionSetAssignment WHERE PermissionSet.PermissionsModifyAllData = true];
-			for (PermissionSetAssignment psa:modifiers){
-				if (psa.AssigneeId == userInfo.getUserID()){
-					system.debug('edit allowed because admin');
-					return true;
-				}
-			}
+            String query = 'SELECT RecordId, HasDeleteAccess, HasAllAccess FROM UserRecordAccess WHERE RecordId = \'' + String.escapeSingleQuotes(string.valueOf(recordId)) + '\' AND UserId = \'' + UserInfo.getUserId() + '\'';
+            sObject o = Database.query(query);
+            if ((Boolean)o.get('HasDeleteAccess') || (Boolean)o.get('HasAllAccess')){
+                System.Debug('edit allowed because user has full acesss or modify all permissions');
+                return true;
+            }
 		} catch (system.queryException e){
 			//it's possible you can't even see that record and the queries are null!
 			return false;


### PR DESCRIPTION
Fixed the issue that people who are above the Owner in the role-hierarchy could not extend the sharing while this is allowed in Salesforce.